### PR TITLE
DX-2674 | Google auth app verification

### DIFF
--- a/src/app/Routes.tsx
+++ b/src/app/Routes.tsx
@@ -45,6 +45,12 @@ const AboutModule = lazy(
 const WhyDXModule = lazy(
   () => import("app/modules/home-module/sub-modules/why-dx")
 );
+const PrivacyPolicyModule = lazy(
+  () => import("app/modules/home-module/sub-modules/privacy-policy")
+);
+const TermsAndConditionsModule = lazy(
+  () => import("app/modules/home-module/sub-modules/terms-and-conditions")
+);
 
 const PricingModule = lazy(
   () => import("app/modules/home-module/sub-modules/pricing")
@@ -314,6 +320,12 @@ export function MainRoutes() {
             <AuthProtectedRoute>
               <ChartModule />
             </AuthProtectedRoute>
+          </RouteWithAppBar>
+          <RouteWithAppBar exact path="/privacy-policy">
+            <PrivacyPolicyModule />
+          </RouteWithAppBar>
+          <RouteWithAppBar exact path="/terms-and-conditions">
+            <TermsAndConditionsModule />
           </RouteWithAppBar>
 
           <Route exact path="/chart-embed/:chartId/:datasetId">

--- a/src/app/modules/chart-module/util/constants/index.ts
+++ b/src/app/modules/chart-module/util/constants/index.ts
@@ -1,7 +1,5 @@
-export const PRIVACY_POLICY_LINK =
-  "https://drive.google.com/file/d/1_0g-ug1_e0f9CycSsnZzEZ736XkBsdPr/view?usp=drive_link";
-export const TERMS_AND_CONDITION_LINK =
-  "https://drive.google.com/file/d/1N3j8TxKlWTRPHKlzNNwedBzmpO6EDu6J/view?usp=drive_link";
+export const PRIVACY_POLICY_LINK = `${process.env.PUBLIC_URL}/privacy-policy`;
+export const TERMS_AND_CONDITION_LINK = `${process.env.PUBLIC_URL}/terms-and-conditions`;
 export const COOKIE_POLICY_LINK =
   "https://drive.google.com/file/d/1p0zjAZ1_UKYiK4gFnpkLzN_8gy0E3td2/view?usp=drive_link";
 export const DATA_POLICY_LINK =

--- a/src/app/modules/home-module/components/Footer/DesktopFooter.tsx
+++ b/src/app/modules/home-module/components/Footer/DesktopFooter.tsx
@@ -510,25 +510,15 @@ export default function DesktopFooter(props: Props) {
             />
             <p>
               {" "}
-              <a
-                href={PRIVACY_POLICY_LINK}
-                className="privacy-link"
-                target="_blank"
-                rel="noreferrer"
-              >
+              <Link to={PRIVACY_POLICY_LINK} className="privacy-link">
                 Privacy
-              </a>{" "}
+              </Link>{" "}
             </p>
             <p>
               {" "}
-              <a
-                href={TERMS_AND_CONDITION_LINK}
-                className="privacy-link"
-                target="_blank"
-                rel="noreferrer"
-              >
+              <Link to={TERMS_AND_CONDITION_LINK} className="privacy-link">
                 Terms and conditions
-              </a>{" "}
+              </Link>
             </p>
           </nav>
         </Container>

--- a/src/app/modules/home-module/sub-modules/privacy-policy/index.tsx
+++ b/src/app/modules/home-module/sub-modules/privacy-policy/index.tsx
@@ -1,0 +1,202 @@
+import React from "react";
+import { useTitle } from "react-use";
+import { Box, Container } from "@material-ui/core";
+import Hero from "app/modules/home-module/components/hero";
+import HomeFooter from "app/modules/home-module/components/Footer";
+
+export default function PrivacyPolicyModule() {
+  useTitle("Dataxplorer - Privacy Policy");
+
+  return (
+    <div
+      css={`
+        display: flex;
+        flex-direction: column;
+        justify-content: space-between;
+        margin-top: 50px;
+        min-height: calc(100vh - 50px);
+        @media (max-width: 880px) {
+          margin-top: 66px;
+          min-height: calc(100vh - 66px);
+        }
+      `}
+    >
+      <main
+        css={`
+          padding-bottom: 100px;
+          @media (max-width: 960px) {
+            padding-bottom: 40px;
+          }
+          background-color: linear-gradient(
+            180deg,
+            rgba(255, 255, 255, 0) 0%,
+            #f2f7fd 100%
+          );
+        `}
+      >
+        <Hero title="Privacy Policy" />
+
+        <Box
+          height={{
+            xs: 32,
+            md: 40,
+            lg: 80,
+          }}
+        />
+
+        <Container maxWidth="lg">
+          <ol>
+            <li>
+              <b>Introduction</b>
+              <br />
+              Welcome to the Dataxplorer platform! We are committed to
+              protecting your personal information and your right to privacy. If
+              you have any questions or concerns about our policy, or our
+              practices with regards to your personal information, please
+              contact us at privacy@zimmerman.team.
+            </li>
+            <br />
+            <li>
+              <b>Information We Collect</b>
+              <br />
+              We collect personal information that you voluntarily provide to us
+              when registering at the Dataxplorer platform, expressing an
+              interest in obtaining information about us or our products and
+              services, when purchasing a product or service, or otherwise
+              contacting us. The personal information that we collect depends on
+              the context of your interactions with us and the Dataxplorer
+              platform, the choices you make and the products and features you
+              use. The personal information we collect can include the
+              following:
+              <br />
+              <b>Name and Contact Data.</b> We collect your first and last name,
+              email address, and other similar contact data.
+              <br />
+              <b>Credentials.</b> We do not collect passwords or password hints.
+              Security information used for authentication and account access is
+              managed by Auth0 1 a trusted third party that handles
+              authentication and authorisation in between your business account
+              and the Dataxplorer platform.
+              <br />
+              <b>Payment Data.</b> We collect data necessary to process your
+              payment if you make purchases, such as your payment instrument
+              number (such as a credit card number), and the security code
+              associated with your payment instrument. All payment data is
+              stored by our payment processor and you should review its privacy
+              policies and contact the payment processor directly to respond to
+              your questions. All payment processing is handled by{" "}
+              <a
+                target="_blank"
+                href="https://stripe.com"
+                rel="noopener noreferrer"
+              >
+                Stripe
+              </a>
+              , a trusted third party that handles payments in between your
+              payment gateway (credit card, bank etc.) and the Dataxplorer
+              platform.
+              <br />
+              <b>
+                All Personal Information that you provide to us must be true,
+                complete and accurate, and you must notify us of any changes to
+                such personal or business information.
+              </b>
+              <br />
+            </li>
+            <br />
+            <li>
+              <b>How We Use Your Information</b>
+              <br />
+              We use personal information collected via our Site for a variety
+              of business purposes described below. We process your personal
+              information for these purposes in reliance on our legitimate
+              business interests, in order to enter into or perform a contract
+              with you, with your consent, and/or for compliance with our legal
+              obligations. We indicate the specific processing grounds we rely
+              on next to each purpose listed below.
+              <br />
+              We use the information we collect or receive:
+              <br />
+              <b>To send you marketing and promotional communications.</b> We
+              and/or our third-party marketing partners may use the personal
+              information you send to us for marketing purposes, if this is in
+              accordance with your marketing preferences. You can opt-out of our
+              marketing emails at any time (see the "What are your privacy
+              rights" below).
+              <br />
+              <b>To send administrative information to you.</b> We may use your
+              personal information to send you product, service and new feature
+              information and/or information about changes to our terms,
+              conditions, and policies.
+              <br />
+              <b>To fulfill and manage your orders.</b> We may use your
+              information to fulfill and manage your orders, payments, returns,
+              and exchanges made through the Dataxplorer platform.
+              <br />
+              <b>To protect our Dataxplorer platform.</b> We may use your
+              information as part of our efforts to keep our Dataxplorer
+              platform safe and secure (for example, for fraud monitoring and
+              prevention).
+              <br />
+              <b>To enforce our terms, conditions and policies.</b>
+              <br />
+              <b>To respond to legal requests and prevent harm.</b> If we
+              receive a subpoena or other legal request, we may need to inspect
+              the data we hold to determine how to respond.
+            </li>
+            <br />
+            <li>
+              <b>Will Your Information Be Shared With Anyone?</b>
+              <br />
+              We may process or share data based on the following legal basis:
+              <br />
+              <b>Consent:</b> We may process your data if you have given us
+              specific consent to use your personal information in a specific
+              purpose.
+              <br />
+              <b>Legitimate Interests:</b> We may process your data when it is
+              reasonably necessary to achieve our legitimate business interests.
+              <br />
+              <b>Performance of a Contract:</b> Where we have entered into a
+              contract with you, we may process your personal information to
+              fulfill the terms of our contract.
+              <br />
+              <b>Legal Obligations:</b> We may disclose your information where
+              we are legally required to do so in order to comply with
+              applicable law, governmental requests, a judicial proceeding,
+              court order, or legal process, such as in response to a court
+              order or a subpoena (including in response to public authorities
+              to meet national security or law enforcement requirements).
+              <br />
+              <b>Other legal requirements:</b> We may process your information
+              in order to protect your vital interests or those of a third party
+              (e.g., to prevent harm).
+            </li>
+            <br />
+            <li>
+              <b>Do We Use Cookies and Other Tracking Technologies?</b>
+              <br />
+              We may use cookies and other tracking technologies (like web
+              beacons and pixels) to access or store information. Specific
+              information about how we use such technologies and how you can
+              refuse certain cookies is set out in our Cookie Policy
+            </li>
+            <br />
+            <li>
+              <b>How Long Do We Keep Your Information?</b>
+              <br />
+              We will only keep your personal information for as long as it is
+              necessary for the purposes set out in this privacy policy, unless
+              a longer retention period is required or permitted by law (such as
+              tax, accounting or other legal requirements). When we have no
+              ongoing legitimate business need to process your personal
+              information, we will either delete or anonymize your personal
+              information.
+            </li>
+          </ol>
+        </Container>
+      </main>
+      <HomeFooter />
+    </div>
+  );
+}

--- a/src/app/modules/home-module/sub-modules/terms-and-conditions/index.tsx
+++ b/src/app/modules/home-module/sub-modules/terms-and-conditions/index.tsx
@@ -1,0 +1,231 @@
+import React from "react";
+import { useTitle } from "react-use";
+import { Box, Container } from "@material-ui/core";
+import Hero from "app/modules/home-module/components/hero";
+import HomeFooter from "app/modules/home-module/components/Footer";
+
+export default function TermsAndConditionsModule() {
+  useTitle("Dataxplorer - Terms and Conditions");
+
+  return (
+    <div
+      css={`
+        display: flex;
+        flex-direction: column;
+        justify-content: space-between;
+        margin-top: 50px;
+        min-height: calc(100vh - 50px);
+        @media (max-width: 880px) {
+          margin-top: 66px;
+          min-height: calc(100vh - 66px);
+        }
+      `}
+    >
+      <main
+        css={`
+          padding-bottom: 100px;
+          @media (max-width: 960px) {
+            padding-bottom: 40px;
+          }
+          background-color: linear-gradient(
+            180deg,
+            rgba(255, 255, 255, 0) 0%,
+            #f2f7fd 100%
+          );
+        `}
+      >
+        <Hero title="Terms & Conditions" />
+
+        <Box
+          height={{
+            xs: 32,
+            md: 40,
+            lg: 80,
+          }}
+        />
+
+        <Container maxWidth="lg">
+          <b>Introduction</b>
+          <br />
+          These Terms and Conditions ("Terms") govern the use of the Dataxplorer
+          platform ("Platform"), a software-as-a-service ("SaaS") data platform
+          provided by Zimmerman BV ("Company"). By accessing or using the
+          Platform, you ("Customer" or "you") agree to be bound by these Terms.
+          <br />
+          <b>Definitions</b>
+          <br />
+          <ul>
+            <li>
+              "Account" means the account created by Customer to access the
+              Platform.
+            </li>
+            <li>
+              "Content" means all data, information, and materials uploaded,
+              posted, or stored on the Platform by Customer
+            </li>
+            <li>
+              "Subscription" means the subscription plan chosen by Customer to
+              access the Platform.
+            </li>
+            <li>
+              "User" means an individual authorized by Customer to access the
+              Platform.
+            </li>
+          </ul>
+          <br />
+          <b>Use of the Platform</b>
+          <br />
+          <ol>
+            <li>
+              <b>Eligibility:</b> The Platform is only available to individuals
+              who are at least 18 years old and capable of forming a binding
+              contract.
+            </li>
+            <li>
+              <b>Account Creation:</b> To access the Platform, Customer must
+              create an Account by providing accurate and complete information.
+            </li>
+            <li>
+              <b>Subscription:</b> Customer must choose a Subscription plan to
+              access the Platform. The Subscription plan will determine the
+              features and limitations of the Platform available to Customer.
+            </li>
+            <li>
+              <b>User Access:</b> Customer may authorize Users to access the
+              Platform. Customer is responsible for ensuring that all Users
+              comply with these Terms.
+            </li>
+          </ol>
+          <br />
+          <b>Content and Data</b>
+          <br />
+          <ol>
+            <li>
+              <b>Content Ownership:</b> Customer retains ownership of all
+              Content uploaded, posted, or stored on the Platform.
+            </li>
+            <li>
+              <b>Content Responsibility:</b> Customer is responsible for
+              ensuring that all Content complies with applicable laws and
+              regulations.
+            </li>
+            <li>
+              <b>Data Processing:</b> The Company will process Content in
+              accordance with its privacy policy and applicable data protection
+              laws.
+            </li>
+          </ol>
+          <br />
+          <b>Payment and Subscription</b>
+          <br />
+          <ol>
+            <li>
+              <b>Fees:</b> Customer must pay all fees associated with the chosen
+              Subscription plan.
+            </li>
+            <li>
+              <b>Payment Terms:</b> Payment is due upon receipt of invoice. Late
+              payments may incur additional fees.
+            </li>
+            <li>
+              <b>Subscription Renewal:</b> The Subscription will automatically
+              renew unless Customer cancels at least 30 days prior to the end of
+              the current term.
+            </li>
+          </ol>
+          <br />
+          <b>Security and Support</b>
+          <br />
+          <ol>
+            <li>
+              <b>Security:</b> The Company will maintain reasonable security
+              measures to protect the Platform and Customer Content.
+            </li>
+            <li>
+              <b>Support:</b> The Company will provide reasonable support to
+              Customer via email, phone, or online resources.
+            </li>
+          </ol>
+          <br />
+          <b>Intellectual Property</b>
+          <br />
+          <ol>
+            <li>
+              <b>Platform Ownership:</b> The Company retains ownership of all
+              intellectual property rights in the Platform.
+            </li>
+            <li>
+              <b>Content License:</b> Customer grants the Company a
+              non-exclusive, royalty-free license to use, reproduce, and display
+              Content for the purpose of providing the Platform.
+            </li>
+          </ol>
+          <br />
+          <b>Warranties and Disclaimers</b>
+          <br />
+          <ol>
+            <li>
+              <b>Warranty Disclaimer:</b> The Platform is provided "as-is" and
+              "as-available" without warranties of any kind.
+            </li>
+            <li>
+              <b>Limitation of Liability:</b> The Company's liability for
+              damages is limited to the amount paid by Customer in the 12 months
+              preceding the claim.
+            </li>
+          </ol>
+          <br />
+          <b>Termination</b>
+          <br />
+          <ol>
+            <li>
+              <b>Termination:</b> Either party may terminate the Subscription
+              upon written notice to the other party.
+            </li>
+            <li>
+              <b>Effect of Termination:</b> Upon termination, Customer will no
+              longer have access to the Platform, and all Content will be
+              deleted.
+            </li>
+          </ol>
+          <br />
+          <b>Governing Law</b>
+          <br />
+          <ol>
+            <li>
+              <b>Governing Law:</b> These Terms will be governed by and
+              construed in accordance with the laws of [State/Country].
+            </li>
+            <li>
+              <b>Dispute Resolution:</b> Any disputes arising out of or related
+              to these Terms will be resolved through [Dispute Resolution
+              Process].
+            </li>
+          </ol>
+          <br />
+          <b>Changes to Terms</b>
+          <br />
+          <ol>
+            <li>
+              <b>Changes:</b> The Company may modify these Terms at any time.
+            </li>
+            <li>
+              <b>Notice:</b> The Company will provide notice of changes to these
+              Terms by posting an updated version on the Platform.
+            </li>
+          </ol>
+          <br />
+          <b>Contact</b>
+          <br />
+          If you have any questions or concerns about these Terms, please
+          contact us at{" "}
+          <a href="mailto:privacy@zimmerman.team">privacy@zimmerman.team</a> at
+          our HQ based in Amsterdam on Keizersgracht 520H, 1017 EK, Amsterdam,
+          The Netherlands. By using the Platform, you acknowledge that you have
+          read, understand, and agree to be bound by these Terms.
+        </Container>
+      </main>
+      <HomeFooter />
+    </div>
+  );
+}


### PR DESCRIPTION
Moved Privacy Policy and Terms & Conditions to in-app pages
- http://localhost:3001/privacy-policy
- http://localhost:3001/terms-and-conditions

This was done because Google Console Auth app verification process doesn't accept links of PDFs for these 2 subjects.
(reference: https://support.google.com/cloud/answer/13806988?hl=en-GB#zippy=%2Cthe-provided-privacy-policy-url-is-unresponsive%2Cyour-privacy-policy-is-improperly-formatted)